### PR TITLE
Fix Coq CI

### DIFF
--- a/theories/dune
+++ b/theories/dune
@@ -8,4 +8,4 @@
  (target Parser.v)
  (deps Parser.vy)
  (action
-  (run menhir --coq %{deps})))
+  (run menhir --coq --coq-no-version-check %{deps})))


### PR DESCRIPTION
@liyishuai we need this to keep coq-json compiling in Coq CI (c.f. https://github.com/coq/coq/blob/master/dev/ci/ci-json.sh , it's also the configuration in Compcert and VST makefiles)